### PR TITLE
efficiently updating mp[i][diff] to avoid overwriting previous counts during dynamic programming

### DIFF
--- a/DP/Arithmetic Slices II - Subsequence.cpp
+++ b/DP/Arithmetic Slices II - Subsequence.cpp
@@ -21,7 +21,7 @@ public:
                 
                 int count_at_j = it==end(mp[j]) ? 0 : it->second;
                 
-                mp[i][diff] = count_at_j+1;
+                mp[i][diff] += count_at_j+1;
                 result    += count_at_j;
                 
             }


### PR DESCRIPTION
In the previous implementation, the line 'mp[i][diff] = count_at_j + 1;' was replacing the existing value in mp[i][diff] instead of accumulating the counts. This oversight resulted in the incorrect counting in test cases like [7,7,7,7,7]
![image](https://github.com/MAZHARMIK/Interview_DS_Algo/assets/74665251/f76d1524-b805-4165-8304-d3bc2709b191)
