### PR TITLE
Null pointer exception in java code removed

### DIFF
--- a/Graph/Divide Nodes Into the Maximum Number of Groups.cpp
+++ b/Graph/Divide Nodes Into the Maximum Number of Groups.cpp
@@ -189,8 +189,8 @@ class Solution {
             int u = edge[0] - 1;
             int v = edge[1] - 1;
             
-            adj.computeIfAbsent(u, k -> new ArrayList<>()).add(v);
-            adj.computeIfAbsent(v, k -> new ArrayList<>()).add(u);
+            adj.get(u).add(v);
+            adj.get(v).add(u);
         }
 
         // Bipartite check


### PR DESCRIPTION
The issue arises because some nodes in the graph might not have any neighboring nodes, which means they won't be present in the adjacency map. When the code tries to access the adjacency list for such nodes, it results in a NullPointerException.